### PR TITLE
Add support for dmtx encode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ dist
 .tox
 README.rst
 .coverage
+htmlcov
 *dll
 MANIFEST.in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v0.2.0
+
+* #18 Encode support
+
 ### v0.1.8
 
 * #16 Improve error messages

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ You can also provide a tuple `(pixels, width, height)`
  Decoded(data='Plesiosaurus', rect=Rect(left=298, top=6, width=95, height=95))]
 ```
 
+The encoding function returns raw bytes:
+
+```
+>>> w, h, bpp, pixels = encode('hello world')
+>>> img = Image.frombytes('RGB', (w, h), pixels)
+>>> img.save('dmtx.png')
+```
+
 ## Windows error message
 If you see an ugly `ImportError` when importing `pylibdmtx` on Windows you will
 most likely need the
@@ -82,8 +90,6 @@ Install `vcredist_x64.exe` if using 64-bit Python, `vcredist_x86.exe` if using
 ## Limitations
 
 Feel free to submit a PR to address any of these.
-
-* decoding only - no encoding
 
 * I took the bone-headed approach of copying the logic in
 `pydmtx`'s `decode` function

--- a/pylibdmtx/__init__.py
+++ b/pylibdmtx/__init__.py
@@ -1,3 +1,3 @@
 """Read Data Matrix barcodes from Python 2 and 3."""
 
-__version__ = '0.1.7'
+__version__ = '0.2.0'

--- a/pylibdmtx/pylibdmtx.py
+++ b/pylibdmtx/pylibdmtx.py
@@ -1,8 +1,9 @@
 from __future__ import print_function
 
+import ctypes
 from collections import namedtuple
 from contextlib import contextmanager
-from ctypes import byref, cast, string_at
+from ctypes import byref, cast, string_at, c_char_p
 
 from .pylibdmtx_error import PyLibDMTXError
 from .wrapper import (
@@ -10,8 +11,9 @@ from .wrapper import (
     dmtxDecodeDestroy, dmtxRegionDestroy, dmtxMessageDestroy, dmtxTimeAdd,
     dmtxTimeNow, dmtxDecodeMatrixRegion, dmtxRegionFindNext,
     dmtxMatrix3VMultiplyBy, dmtxDecodeSetProp, DmtxPackOrder, DmtxProperty,
-    DmtxUndefined, DmtxVector2, EXTERNAL_DEPENDENCIES
-)
+    DmtxUndefined, DmtxVector2, EXTERNAL_DEPENDENCIES,
+    DmtxSymbolSize, DmtxScheme, dmtxEncodeSetProp, dmtxEncodeDataMatrix, dmtxImageGetProp, dmtxEncodeCreate,
+    dmtxEncodeDestroy)
 
 __all__ = ['decode', 'EXTERNAL_DEPENDENCIES']
 
@@ -272,3 +274,69 @@ def decode(image, timeout=None, gap_size=None, shrink=1, shape=None,
                                 break
 
     return results
+
+
+@contextmanager
+def libdmtx_encoder():
+    encoder = dmtxEncodeCreate()
+    if not encoder:
+        raise PyLibDMTXError('Could not create encoder')
+
+    try:
+        yield encoder
+    finally:
+        dmtxEncodeDestroy(byref(encoder))
+
+
+def encode(data, scheme='ascii', symsize=None):
+    """
+    Encodes `data` in a DataMatrix image
+    Args:
+        data: bytes instance
+        scheme: encoding scheme, one of 'ascii', 'base256', 'c40', 'edifact', 'text', 'x12'
+        symsize: symbol size. If `None` it's automatic, otherwise should be a tuple of 2 integars with a valid datamatrix size
+
+    Returns:
+        A tuple: `(width, height, bpp, pixels)`.
+        You can use that to build a PIL image:
+
+            if bpp == 24:
+                Image.frombytes('RGB', (width, height), pxl)
+    """
+    if symsize is not None:
+        sz_name = 'DmtxSymbol{}x{}'.format(*symsize)
+        if not hasattr(DmtxSymbolSize, sz_name):
+            raise ValueError('symsize is not a valid datamatrix size')
+        symsize = getattr(DmtxSymbolSize, sz_name)
+    else:
+        symsize = DmtxSymbolSize.DmtxSymbolShapeAuto
+
+    if scheme is not None:
+        scheme = scheme.lower().strip()
+        schemes = {
+            'ascii': DmtxScheme.DmtxSchemeAscii,
+            'base256': DmtxScheme.DmtxSchemeBase256,
+            'c40': DmtxScheme.DmtxSchemeC40,
+            'edifact': DmtxScheme.DmtxSchemeEdifact,
+            'text': DmtxScheme.DmtxSchemeText,
+            'x12': DmtxScheme.DmtxSchemeX12
+        }
+        try:
+            scheme = schemes[scheme]
+        except KeyError:
+            raise ValueError('scheme must one of this strings: {}'.format(' '.join(schemes.keys())))
+    else:
+        scheme = DmtxScheme.DmtxSchemeAscii
+
+    with libdmtx_encoder() as enc:
+        dmtxEncodeSetProp(enc, DmtxProperty.DmtxPropScheme, scheme)
+        dmtxEncodeSetProp(enc, DmtxProperty.DmtxPropSizeRequest, symsize)
+
+        if dmtxEncodeDataMatrix(enc, len(data), c_char_p(data)) == 0:
+            raise PyLibDMTXError('could not encode data (maybe too long?)')
+        w = dmtxImageGetProp(enc[0].image, DmtxProperty.DmtxPropWidth)
+        h = dmtxImageGetProp(enc[0].image, DmtxProperty.DmtxPropHeight)
+        bpp = dmtxImageGetProp(enc[0].image, DmtxProperty.DmtxPropBitsPerPixel)
+        sz = w * h * bpp // 8
+        pixels = cast(enc[0].image[0].pxl, ctypes.POINTER(ctypes.c_ubyte * sz))
+        return w, h, bpp, ctypes.string_at(pixels, sz)

--- a/pylibdmtx/scripts/create_datamatrix.py
+++ b/pylibdmtx/scripts/create_datamatrix.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import argparse
+import sys
+
+import pylibdmtx
+from pylibdmtx.pylibdmtx import encode
+
+
+def parse_size(s):
+    try:
+        w, h = s.split('x', 1)
+        w, h = int(w), int(h)
+    except ValueError:
+        raise argparse.ArgumentTypeError('Size is not in the format <WIDTH>x<HEIGHT>')
+    return w, h
+
+
+def main(args=None):
+    encoding_list = 'ascii', 'base256', 'c40', 'edifact', 'text', 'x12'
+    if args is None:
+        args = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(
+        description='Creates a png file containing a datamatrix encoded message'
+    )
+    parser.add_argument('output_file', help='Filename of the PNG')
+    parser.add_argument('message', help='Message to encode')
+    parser.add_argument('--size', metavar='WxH', help='Forces datamatrix grid to WxH instead of auto size.', type=parse_size)
+    parser.add_argument('--encoding-scheme', help='Forces encoding method, default is ascii', choices=encoding_list)
+    parser.add_argument(
+        '-v', '--version', action='version',
+        version='%(prog)s ' + pylibdmtx.__version__
+    )
+    args = parser.parse_args(args)
+
+    from PIL import Image
+
+    w, h, bpp, pixels = encode(args.message.encode(), symsize=args.size, scheme=args.encoding_scheme)
+    im = Image.frombytes('RGB', (w, h),pixels)
+    im.save(args.output_file)
+
+if __name__ == '__main__':
+    main()

--- a/pylibdmtx/scripts/create_datamatrix.py
+++ b/pylibdmtx/scripts/create_datamatrix.py
@@ -5,30 +5,20 @@ import argparse
 import sys
 
 import pylibdmtx
-from pylibdmtx.pylibdmtx import encode
-
-
-def parse_size(s):
-    try:
-        w, h = s.split('x', 1)
-        w, h = int(w), int(h)
-    except ValueError:
-        raise argparse.ArgumentTypeError('Size is not in the format <WIDTH>x<HEIGHT>')
-    return w, h
+from pylibdmtx.pylibdmtx import encode, ENCODING_SIZE_NAMES, ENCODING_SCHEME_NAMES
 
 
 def main(args=None):
-    encoding_list = 'ascii', 'base256', 'c40', 'edifact', 'text', 'x12'
     if args is None:
         args = sys.argv[1:]
 
     parser = argparse.ArgumentParser(
-        description='Creates a png file containing a datamatrix encoded message'
+        description='Creates an image containing a datamatrix encoded message'
     )
-    parser.add_argument('output_file', help='Filename of the PNG')
+    parser.add_argument('output_file', help='Filename of the output image')
     parser.add_argument('message', help='Message to encode')
-    parser.add_argument('--size', metavar='WxH', help='Forces datamatrix grid to WxH instead of auto size.', type=parse_size)
-    parser.add_argument('--encoding-scheme', help='Forces encoding method, default is ascii', choices=encoding_list)
+    parser.add_argument('--size', metavar='WxH', help='Forces datamatrix grid to WxH instead of auto size.', choices=ENCODING_SIZE_NAMES)
+    parser.add_argument('--encoding-scheme', help='Forces encoding method, default is ascii', choices=ENCODING_SCHEME_NAMES)
     parser.add_argument(
         '-v', '--version', action='version',
         version='%(prog)s ' + pylibdmtx.__version__

--- a/pylibdmtx/tests/test_create_read_datamatrix.py
+++ b/pylibdmtx/tests/test_create_read_datamatrix.py
@@ -40,14 +40,17 @@ class TestReadDatamatrix(unittest.TestCase):
         self.assertEqual(expected, stdout.getvalue().strip())
 
     def test_create_datamatrix(self):
-        tmpfile = os.path.join(tempfile.mkdtemp(), 'test.png')
-        main_create(['--size', '44x44', tmpfile, 'Stegosaurus'])
-        with capture_stdout() as stdout:
-            main_read([tmpfile])
-        os.unlink(tmpfile)
+        tmpfile = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
+        tmpfile.close()
+        try:
+            main_create(['--size', '44x44', tmpfile.name, 'Stegosaurus'])
+            with capture_stdout() as stdout:
+                main_read([tmpfile.name])
 
-        expected = "Stegosaurus" if 2 == sys.version_info[0] else "b'Stegosaurus'"
-        self.assertEqual(expected, stdout.getvalue().strip())
+            expected = "Stegosaurus" if 2 == sys.version_info[0] else "b'Stegosaurus'"
+            self.assertEqual(expected, stdout.getvalue().strip())
+        finally:
+            os.unlink(tmpfile.name)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pylibdmtx/tests/test_create_read_datamatrix.py
+++ b/pylibdmtx/tests/test_create_read_datamatrix.py
@@ -1,4 +1,6 @@
+import os
 import sys
+import tempfile
 import unittest
 
 from pathlib import Path
@@ -9,7 +11,10 @@ if 2 == sys.version_info[0]:
 else:
     from io import StringIO
 
-from pylibdmtx.scripts.read_datamatrix import main
+from PIL import Image
+
+from pylibdmtx.scripts.read_datamatrix import main as main_read
+from pylibdmtx.scripts.create_datamatrix import main as main_create
 
 
 @contextmanager
@@ -25,7 +30,7 @@ class TestReadDatamatrix(unittest.TestCase):
     def test_read_datamatrix(self):
         "Read datamatrix barcodes"
         with capture_stdout() as stdout:
-            main([str(Path(__file__).parent.joinpath('datamatrix.png'))])
+            main_read([str(Path(__file__).parent.joinpath('datamatrix.png'))])
 
         if 2 == sys.version_info[0]:
             expected = "Stegosaurus\nPlesiosaurus"
@@ -34,6 +39,15 @@ class TestReadDatamatrix(unittest.TestCase):
 
         self.assertEqual(expected, stdout.getvalue().strip())
 
+    def test_create_datamatrix(self):
+        tmpfile = os.path.join(tempfile.mkdtemp(), 'test.png')
+        main_create(['--size', '44x44', tmpfile, 'Stegosaurus'])
+        with capture_stdout() as stdout:
+            main_read([tmpfile])
+        os.unlink(tmpfile)
+
+        expected = "Stegosaurus" if 2 == sys.version_info[0] else "b'Stegosaurus'"
+        self.assertEqual(expected, stdout.getvalue().strip())
 
 if __name__ == '__main__':
     unittest.main()

--- a/pylibdmtx/tests/test_encode.py
+++ b/pylibdmtx/tests/test_encode.py
@@ -1,0 +1,30 @@
+import unittest
+from PIL import Image
+
+from pylibdmtx.pylibdmtx import encode, decode
+from pylibdmtx.pylibdmtx_error import PyLibDMTXError
+
+
+class TestEncode(unittest.TestCase):
+    def test_encode(self):
+        data = b'hello_world'
+        w, h, bpp, pxl = encode(data)
+        im = Image.frombytes('RGB', (w, h), pxl)
+        dec_data = decode(im)
+        self.assertEqual(dec_data[0] .data, data)
+
+        w2, h2, bpp, pxl = encode(data, symsize=(36, 36), scheme='text')
+        im = Image.frombytes('RGB', (w2, h2), pxl)
+        dec_data = decode(im)
+        self.assertEqual(dec_data[0].data, data)
+        self.assertGreater(w2, w)
+        self.assertGreater(h2, h)
+
+    def test_errors(self):
+        self.assertRaises(ValueError, encode, b' ', scheme='asdf')
+        self.assertRaises(ValueError, encode, b' ', symsize=(2,2))
+        self.assertRaises(PyLibDMTXError, encode, b' '*50, symsize=(10, 10))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pylibdmtx/tests/test_encode.py
+++ b/pylibdmtx/tests/test_encode.py
@@ -9,11 +9,12 @@ class TestEncode(unittest.TestCase):
     def test_encode(self):
         data = b'hello_world'
         w, h, bpp, pxl = encode(data)
+        self.assertEqual(bpp, 24)
         im = Image.frombytes('RGB', (w, h), pxl)
         dec_data = decode(im)
         self.assertEqual(dec_data[0] .data, data)
 
-        w2, h2, bpp, pxl = encode(data, symsize=(36, 36), scheme='text')
+        w2, h2, bpp, pxl = encode(data, symsize='36x36', scheme='text')
         im = Image.frombytes('RGB', (w2, h2), pxl)
         dec_data = decode(im)
         self.assertEqual(dec_data[0].data, data)
@@ -23,7 +24,7 @@ class TestEncode(unittest.TestCase):
     def test_errors(self):
         self.assertRaises(ValueError, encode, b' ', scheme='asdf')
         self.assertRaises(ValueError, encode, b' ', symsize=(2,2))
-        self.assertRaises(PyLibDMTXError, encode, b' '*50, symsize=(10, 10))
+        self.assertRaises(PyLibDMTXError, encode, b' '*50, symsize='10x10')
 
 
 if __name__ == '__main__':

--- a/pylibdmtx/wrapper.py
+++ b/pylibdmtx/wrapper.py
@@ -456,7 +456,7 @@ dmtxRegionDestroy = libdmtx_function(
 
 dmtxImageGetProp = libdmtx_function(
     'dmtxImageGetProp',
-    DmtxPassFail,
+    c_int,
     POINTER(DmtxImage),
     c_int,  # prop
 )
@@ -485,5 +485,5 @@ dmtxEncodeDataMatrix = libdmtx_function(
     DmtxPassFail,
     POINTER(DmtxEncode),
     c_int,
-    POINTER(c_char)
+    POINTER(c_ubyte)
 )

--- a/pylibdmtx/wrapper.py
+++ b/pylibdmtx/wrapper.py
@@ -2,7 +2,7 @@
 """
 from ctypes import (
     cdll, c_double, c_int, c_long, c_size_t, c_ubyte, c_uint, c_ulong,
-    c_ulonglong, Structure, CFUNCTYPE, POINTER
+    c_ulonglong, Structure, c_char, CFUNCTYPE, POINTER
 )
 from enum import IntEnum, unique
 
@@ -94,6 +94,55 @@ class DmtxFlip(IntEnum):
     DmtxFlipNone = 0x00
     DmtxFlipX = 0x01 << 0
     DmtxFlipY = 0x01 << 1
+
+
+@unique
+class DmtxScheme(IntEnum):
+    DmtxSchemeAutoFast = -2
+    DmtxSchemeAutoBest = -1
+    DmtxSchemeAscii = 0
+    DmtxSchemeC40 = 1
+    DmtxSchemeText = 2
+    DmtxSchemeX12 = 3
+    DmtxSchemeEdifact = 4
+    DmtxSchemeBase256 = 5
+
+
+@unique
+class DmtxSymbolSize(IntEnum):
+    DmtxSymbolRectAuto = -3
+    DmtxSymbolSquareAuto = -2
+    DmtxSymbolShapeAuto = -1
+    DmtxSymbol10x10 = 0
+    DmtxSymbol12x12 = 1
+    DmtxSymbol14x14 = 2
+    DmtxSymbol16x16 = 3
+    DmtxSymbol18x18 = 4
+    DmtxSymbol20x20 = 5
+    DmtxSymbol22x22 = 6
+    DmtxSymbol24x24 = 7
+    DmtxSymbol26x26 = 8
+    DmtxSymbol32x32 = 9
+    DmtxSymbol36x36 = 10
+    DmtxSymbol40x40 = 11
+    DmtxSymbol44x44 = 12
+    DmtxSymbol48x48 = 13
+    DmtxSymbol52x52 = 14
+    DmtxSymbol64x64 = 15
+    DmtxSymbol72x72 = 16
+    DmtxSymbol80x80 = 17
+    DmtxSymbol88x88 = 18
+    DmtxSymbol96x96 = 19
+    DmtxSymbol104x104 = 20
+    DmtxSymbol120x120 = 21
+    DmtxSymbol132x132 = 22
+    DmtxSymbol144x144 = 23
+    DmtxSymbol8x18 = 24
+    DmtxSymbol8x32 = 25
+    DmtxSymbol12x26 = 26
+    DmtxSymbol12x36 = 27
+    DmtxSymbol16x36 = 28
+    DmtxSymbol16x48 = 29
 
 
 # Types
@@ -268,6 +317,32 @@ class DmtxRegion(Structure):
     ]
 
 
+class DmtxEncode(Structure):
+    _fields_ = [
+        ('method', c_int),
+        ('scheme', c_int),
+        ('sizeIdxRequest', c_int),
+        ('marginSize', c_int),
+        ('moduleSize', c_int),
+        ('pixelPacking', c_int),
+        ('imageFlip', c_int),
+        ('rowPadBytes', c_int),
+        ('message', POINTER(DmtxMessage)),
+        ('image', POINTER(DmtxImage)),
+        ('region', DmtxRegion),
+        ('xfrm', DmtxMatrix3),
+        ('rxfrm', DmtxMatrix3),
+    ]
+
+# Globals populated in load_libdmtx
+LIBDMTX = None
+"""ctypes.CDLL
+"""
+
+EXTERNAL_DEPENDENCIES = []
+"""Sequence of instances of ctypes.CDLL
+"""
+
 def load_libdmtx():
     """Loads the libdmtx shared library.
 
@@ -377,4 +452,38 @@ dmtxRegionDestroy = libdmtx_function(
     'dmtxRegionDestroy',
     DmtxPassFail,
     POINTER(POINTER(DmtxRegion))
+)
+
+dmtxImageGetProp = libdmtx_function(
+    'dmtxImageGetProp',
+    DmtxPassFail,
+    POINTER(DmtxImage),
+    c_int,  # prop
+)
+
+dmtxEncodeCreate = libdmtx_function(
+    'dmtxEncodeCreate',
+    POINTER(DmtxEncode),
+)
+
+dmtxEncodeDestroy = libdmtx_function(
+    'dmtxEncodeDestroy',
+    DmtxPassFail,
+    POINTER(POINTER(DmtxEncode))
+)
+
+dmtxEncodeSetProp = libdmtx_function(
+    'dmtxEncodeSetProp',
+    DmtxPassFail,
+    POINTER(DmtxEncode),
+    c_int,    # prop
+    c_int     # value
+)
+
+dmtxEncodeDataMatrix = libdmtx_function(
+    'dmtxEncodeDataMatrix',
+    DmtxPassFail,
+    POINTER(DmtxEncode),
+    c_int,
+    POINTER(c_char)
 )

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup_data = {
     'name': 'pylibdmtx',
     'version': pylibdmtx.__version__,
     'author': 'Lawrence Hudson',
-    'author_email': 'l.hudson@nhm.ac.uk',
+    'author_email': 'quicklizard@googlemail.com',
     'url': URL,
     'license': 'MIT',
     'description': pylibdmtx.__doc__,
@@ -49,8 +49,9 @@ setup_data = {
     },
     'tests_require': [
         # TODO How to specify OpenCV? 'cv2>=2.4.8',
-        PILLOW,
+        'mock>=2.0.0; python_version=="2.7"',
         'numpy>=1.8.2',
+        PILLOW,
     ],
     'include_package_data': True,
     'classifiers': [

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 import pylibdmtx
 
 
-SCRIPTS = ['read_datamatrix']
+SCRIPTS = ['read_datamatrix', 'create_datamatrix']
 
 # Optional dependency
 PILLOW = 'Pillow>=3.2.0'


### PR DESCRIPTION
Add an encode() fuction that returns width height bpp and pixel data, which can be used then by the user with cv2. PIL or whatever library.