### PR TITLE
export the API of the pylibdmtx module at package scope

### DIFF
--- a/pylibdmtx/__init__.py
+++ b/pylibdmtx/__init__.py
@@ -1,3 +1,5 @@
 """Read and write Data Matrix barcodes from Python 2 and 3."""
 
 __version__ = '0.1.8'
+
+from .pylibdmtx import *


### PR DESCRIPTION
Users can now access the top-level API with 'import pylibdmtx',
instead of 'from pylibdmtx import pylibdmtx'. This is arguably
more discoverable.

Closes #26.