### PR TITLE
add fields to libdmtx datastructures that were added in v0.7.5

### DIFF
--- a/pylibdmtx/wrapper.py
+++ b/pylibdmtx/wrapper.py
@@ -5,6 +5,7 @@ from ctypes import (
     c_ulonglong, c_char_p, Structure, CFUNCTYPE, POINTER
 )
 from enum import IntEnum, unique
+from distutils.version import LooseVersion
 
 from . import dmtx_library
 
@@ -251,6 +252,10 @@ class DmtxMessage(Structure):
         ('code', c_ubyte_p),
         ('output', c_ubyte_p),
     ]
+# libdmtx added an extra field in v0.7.5, breaking API
+# backwards compatibility.
+if LooseVersion(dmtxVersion()) < LooseVersion('0.7.5'):
+    del DmtxMessage._fields_[5]
 
 
 class DmtxImage(Structure):
@@ -360,7 +365,10 @@ class DmtxDecode(Structure):
         ('image', POINTER(DmtxImage)),
         ('grid', DmtxScanGrid),
     ]
-
+# libdmtx added an extra field in v0.7.5, breaking API
+# backwards compatibility.
+if LooseVersion(dmtxVersion()) < LooseVersion('0.7.5'):
+    del DmtxDecode._fields_[3]
 
 class DmtxRegion(Structure):
     _fields_ = [
@@ -424,6 +432,10 @@ class DmtxEncode(Structure):
         ('xfrm', DmtxMatrix3),
         ('rxfrm', DmtxMatrix3),
     ]
+# libdmtx added an extra field in v0.7.5, breaking API
+# backwards compatibility.
+if LooseVersion(dmtxVersion()) < LooseVersion('0.7.5'):
+    del DmtxEncode._fields_[8]
 
 # Function signatures
 

--- a/pylibdmtx/wrapper.py
+++ b/pylibdmtx/wrapper.py
@@ -42,6 +42,7 @@ class DmtxProperty(IntEnum):
     DmtxPropSizeRequest = 101
     DmtxPropMarginSize = 102
     DmtxPropModuleSize = 103
+    DmtxPropFnc1 = 104
     # Decoding properties
     DmtxPropEdgeMin = 200
     DmtxPropEdgeMax = 201
@@ -207,6 +208,7 @@ class DmtxMessage(Structure):
         ('outputSize', c_size_t),
         ('outputIdx', c_int),
         ('padCount', c_int),
+        ('fnc1', c_int),
         ('array', c_ubyte_p),
         ('code', c_ubyte_p),
         ('output', c_ubyte_p),
@@ -305,6 +307,7 @@ class DmtxDecode(Structure):
         ('edgeMin', c_int),
         ('edgeMax', c_int),
         ('scanGap', c_int),
+        ('fnc1', c_int),
         ('squareDevn', c_double),
         ('sizeIdxExpected', c_int),
         ('edgeThresh', c_int),
@@ -376,6 +379,7 @@ class DmtxEncode(Structure):
         ('pixelPacking', c_int),
         ('imageFlip', c_int),
         ('rowPadBytes', c_int),
+        ('fnc1', c_int),
         ('message', POINTER(DmtxMessage)),
         ('image', POINTER(DmtxImage)),
         ('region', DmtxRegion),

--- a/pylibdmtx/wrapper.py
+++ b/pylibdmtx/wrapper.py
@@ -2,7 +2,7 @@
 """
 from ctypes import (
     cdll, c_double, c_int, c_long, c_size_t, c_ubyte, c_uint, c_ulong,
-    c_ulonglong, Structure, CFUNCTYPE, POINTER
+    c_ulonglong, c_char_p, Structure, CFUNCTYPE, POINTER
 )
 from enum import IntEnum, unique
 
@@ -64,6 +64,14 @@ c_ubyte_p = POINTER(c_ubyte)
 
 # Defines and enums
 DmtxUndefined = -1
+
+# We define this function early so that we can use it in the
+# structure definitions below.
+
+_dmtxVersion = libdmtx_function('dmtxVersion', c_char_p)
+
+def dmtxVersion():
+    return _dmtxVersion().decode()
 
 
 @unique

--- a/pylibdmtx/wrapper.py
+++ b/pylibdmtx/wrapper.py
@@ -27,6 +27,36 @@ EXTERNAL_DEPENDENCIES = []
 """List of instances of ctypes.CDLL. Helpful when freezing.
 """
 
+def load_libdmtx():
+    """Loads the libdmtx shared library.
+
+    Populates the globals LIBDMTX and EXTERNAL_DEPENDENCIES.
+    """
+    global LIBDMTX
+    global EXTERNAL_DEPENDENCIES
+    if not LIBDMTX:
+        LIBDMTX = dmtx_library.load()
+        EXTERNAL_DEPENDENCIES = [LIBDMTX]
+
+    return LIBDMTX
+
+
+def libdmtx_function(fname, restype, *args):
+    """Returns a foreign function exported by `libdmtx`.
+
+    Args:
+        fname (:obj:`str`): Name of the exported function as string.
+        restype (:obj:): Return type - one of the `ctypes` primitive C data
+        types.
+        *args: Arguments - a sequence of `ctypes` primitive C data types.
+
+    Returns:
+        cddl.CFunctionType: A wrapper around the function.
+    """
+    prototype = CFUNCTYPE(restype, *args)
+    return prototype((fname, load_libdmtx()))
+
+
 # Types
 c_ubyte_p = POINTER(c_ubyte)
 """unsigned char* type
@@ -387,45 +417,7 @@ class DmtxEncode(Structure):
         ('rxfrm', DmtxMatrix3),
     ]
 
-# Globals populated in load_libdmtx
-LIBDMTX = None
-"""ctypes.CDLL
-"""
-
-EXTERNAL_DEPENDENCIES = []
-"""Sequence of instances of ctypes.CDLL
-"""
-
-def load_libdmtx():
-    """Loads the libdmtx shared library.
-
-    Populates the globals LIBDMTX and EXTERNAL_DEPENDENCIES.
-    """
-    global LIBDMTX
-    global EXTERNAL_DEPENDENCIES
-    if not LIBDMTX:
-        LIBDMTX = dmtx_library.load()
-        EXTERNAL_DEPENDENCIES = [LIBDMTX]
-
-    return LIBDMTX
-
-
 # Function signatures
-def libdmtx_function(fname, restype, *args):
-    """Returns a foreign function exported by `libdmtx`.
-
-    Args:
-        fname (:obj:`str`): Name of the exported function as string.
-        restype (:obj:): Return type - one of the `ctypes` primitive C data
-        types.
-        *args: Arguments - a sequence of `ctypes` primitive C data types.
-
-    Returns:
-        cddl.CFunctionType: A wrapper around the function.
-    """
-    prototype = CFUNCTYPE(restype, *args)
-    return prototype((fname, load_libdmtx()))
-
 
 dmtxTimeNow = libdmtx_function('dmtxTimeNow', DmtxTime)
 


### PR DESCRIPTION
Between v0.7.4 and v0.7.5 libdmtx added a field to the internal
datastructures, which were not included into the wrapper in pylibdmtx.
The wrapper thus uses incorrect offsets to access the elements of the
datastructures, and this causes strange errors.

Reported upstream: https://github.com/dmtx/libdmtx/issues/21

Closes #24.