### PR TITLE
Added optional argument to decode method to allow binary data decoded

### DIFF
--- a/pylibdmtx/pylibdmtx.py
+++ b/pylibdmtx/pylibdmtx.py
@@ -146,11 +146,13 @@ def _decoded_matrix_region(decoder, region, corrections):
             dmtxMessageDestroy(byref(message))
 
 
-def _decode_region(decoder, region, corrections, shrink):
+def _decode_region(decoder, region, corrections, shrink, binary=False):
     """Decodes and returns the value in a region.
 
     Args:
         region (DmtxRegion):
+        binary (boolean): flag to set interepretation of decoded message as binary bytes rather 
+            than as a zero terminated cstring.
 
     Yields:
         Decoded or None: The decoded value.
@@ -169,8 +171,13 @@ def _decode_region(decoder, region, corrections, shrink):
             y0 = int((shrink * p00.Y) + 0.5)
             x1 = int((shrink * p11.X) + 0.5)
             y1 = int((shrink * p11.Y) + 0.5)
+            if binary:
+                decodedbuf = cast(msg.contents.output, ctypes.POINTER(ctypes.c_ubyte * msg.contents.outputIdx))[0]
+                payload = bytes(decodedbuf)
+            else:
+                payload = string_at(msg.contents.output)
             return Decoded(
-                string_at(msg.contents.output),
+                payload,
                 Rect(x0, y0, x1 - x0, y1 - y0)
             )
         else:
@@ -225,7 +232,7 @@ def _pixel_data(image):
 
 def decode(image, timeout=None, gap_size=None, shrink=1, shape=None,
            deviation=None, threshold=None, min_edge=None, max_edge=None,
-           corrections=None, max_count=None):
+           corrections=None, max_count=None, binary=False):
     """Decodes datamatrix barcodes in `image`.
 
     Args:
@@ -241,7 +248,8 @@ def decode(image, timeout=None, gap_size=None, shrink=1, shape=None,
         corrections (int):
         max_count (int): stop after reading this many barcodes. `None` to read
             as many as possible.
-
+        binary (boolean): tells decoder to interpret decoded message as binary bytes rather 
+            than as a zero terminated cstring
     Returns:
         :obj:`list` of :obj:`Decoded`: The values decoded from barcodes.
     """
@@ -285,7 +293,7 @@ def decode(image, timeout=None, gap_size=None, shrink=1, shape=None,
                     else:
                         # Decoded
                         res = _decode_region(
-                            decoder, region, corrections, shrink
+                            decoder, region, corrections, shrink, binary=binary
                         )
                         if res:
                             results.append(res)


### PR DESCRIPTION
Hi,
I needed to be able to decode datamatrix codes that were originally encoded with the base256 scheme, but the current decoding support was only for strings.  Zero bytes in the payload were problematic.  So, I added an optional argument binary= to the decode() call.
I'm using Python 3.6 under ubuntu 18.04 for my development.  It seems to pass the existing tests in the tests folder on my box, but I don't know if I created a regression for other platforms or Python versions.
I also did not expand the tests to cover binary payload.
I'm not sure if this is the best way to accomplish what I attempted, but it seems to work for me.
This is my first pull request, so I hope I did it correctly.  Thanks!
-Kurt