### PR TITLE
Add module_size parameter to encode function

### DIFF
--- a/pylibdmtx/pylibdmtx.py
+++ b/pylibdmtx/pylibdmtx.py
@@ -309,7 +309,7 @@ def _encoder():
         dmtxEncodeDestroy(byref(encoder))
 
 
-def encode(data, scheme=None, size=None):
+def encode(data, scheme=None, size=None, module_size=None):
     """
     Encodes `data` in a DataMatrix image.
 
@@ -321,6 +321,8 @@ def encode(data, scheme=None, size=None):
             If `None`, defaults to 'Ascii'.
         size: image dimensions - one of `ENCODING_SIZE_NAMES`, or `None`.
             If `None`, defaults to 'ShapeAuto'.
+        module_size: Module size in pixels, or `None`.
+            If `None`, defaults to 5
 
     Returns:
         Encoded: with properties `(width, height, bpp, pixels)`.
@@ -352,9 +354,12 @@ def encode(data, scheme=None, size=None):
         )
     scheme = getattr(DmtxScheme, scheme_name)
 
+    module_size = module_size if module_size else 5
+
     with _encoder() as encoder:
         dmtxEncodeSetProp(encoder, DmtxProperty.DmtxPropScheme, scheme)
         dmtxEncodeSetProp(encoder, DmtxProperty.DmtxPropSizeRequest, size)
+        dmtxEncodeSetProp(encoder, DmtxProperty.DmtxPropModuleSize, module_size)
 
         if dmtxEncodeDataMatrix(encoder, len(data), cast(data, c_ubyte_p)) == 0:
             raise PyLibDMTXError(

--- a/pylibdmtx/scripts/write_datamatrix.py
+++ b/pylibdmtx/scripts/write_datamatrix.py
@@ -32,6 +32,10 @@ def main(args=None):
         choices=ENCODING_SCHEME_NAMES
     )
     parser.add_argument(
+        '--module_size',
+        help="Module size in pixels; default is '5'"
+    )
+    parser.add_argument(
         '-v', '--version', action='version',
         version='%(prog)s ' + pylibdmtx.__version__
     )
@@ -40,7 +44,7 @@ def main(args=None):
     from PIL import Image
 
     encoded = encode(
-        args.data.encode('utf-8'), size=args.size, scheme=args.scheme
+        args.data.encode('utf-8'), size=args.size, scheme=args.scheme, module_size=args.module_size
     )
     im = Image.frombytes('RGB', (encoded.width, encoded.height), encoded.pixels)
     im.save(args.file)

--- a/pylibdmtx/tests/test_pylibdmtx.py
+++ b/pylibdmtx/tests/test_pylibdmtx.py
@@ -170,6 +170,15 @@ class TestEncode(unittest.TestCase):
 
         self._assert_encoded_data(data, encoded)
 
+    def test_encode_module_size(self):
+        data = b'hello world'
+        encoded = encode(data, size='36x36', module_size=2)
+
+        self.assertEqual(
+            Encoded(width=92, height=92, bpp=24, pixels=None),
+            encoded._replace(pixels=None)
+        )
+
     def test_invalid_scheme(self):
         self.assertRaisesRegexp(
             PyLibDMTXError,


### PR DESCRIPTION
Hi,

I added the parameter for defining the modules size to the encode function. Default seems to be 5 pixels.

Taken from manual page of the dmtxwrite command:
-d, --module=N
              Module size in pixels.

regards,
Alexander