### PR TITLE
decode: ensure full output is returned as a string.

### DIFF
--- a/pylibdmtx/pylibdmtx.py
+++ b/pylibdmtx/pylibdmtx.py
@@ -170,7 +170,7 @@ def _decode_region(decoder, region, corrections, shrink):
             x1 = int((shrink * p11.X) + 0.5)
             y1 = int((shrink * p11.Y) + 0.5)
             return Decoded(
-                string_at(msg.contents.output),
+                string_at(msg.contents.output, msg.contents.outputIdx),
                 Rect(x0, y0, x1 - x0, y1 - y0)
             )
         else:


### PR DESCRIPTION
When decoding base256 binary barcodes the output can be truncated by null charaters when using the default `ctypes.string_at()` function.

This change ensure the full detected / declared length of the output is returned.