### PR TITLE
Return four vertices and Rect object for rotated images

### DIFF
--- a/pylibdmtx/pylibdmtx.py
+++ b/pylibdmtx/pylibdmtx.py
@@ -37,6 +37,7 @@ ENCODING_SIZE_NAMES = [
 
 # A rectangle
 Rect = namedtuple('Rect', 'left top width height')
+Rect_corners = namedtuple('Rect', 'P0 P1 P3 P4')
 
 # Results of reading a barcode
 Decoded = namedtuple('Decoded', 'data rect')
@@ -146,7 +147,7 @@ def _decoded_matrix_region(decoder, region, corrections):
             dmtxMessageDestroy(byref(message))
 
 
-def _decode_region(decoder, region, corrections, shrink):
+def _decode_region(decoder, region, corrections, shrink, four_corners):
     """Decodes and returns the value in a region.
 
     Args:
@@ -160,19 +161,37 @@ def _decode_region(decoder, region, corrections, shrink):
             # Coordinates
             p00 = DmtxVector2()
             p11 = DmtxVector2(1.0, 1.0)
-            dmtxMatrix3VMultiplyBy(
-                p00,
-                region.contents.fit2raw
-            )
+            p10 = DmtxVector2(1.0, 0.0)
+            p01 = DmtxVector2(0.0, 1.0)
+            dmtxMatrix3VMultiplyBy(p00, region.contents.fit2raw)
             dmtxMatrix3VMultiplyBy(p11, region.contents.fit2raw)
-            x0 = int((shrink * p00.X) + 0.5)
-            y0 = int((shrink * p00.Y) + 0.5)
-            x1 = int((shrink * p11.X) + 0.5)
-            y1 = int((shrink * p11.Y) + 0.5)
-            return Decoded(
-                string_at(msg.contents.output),
-                Rect(x0, y0, x1 - x0, y1 - y0)
-            )
+            dmtxMatrix3VMultiplyBy(p01, region.contents.fit2raw)
+            dmtxMatrix3VMultiplyBy(p10, region.contents.fit2raw)
+            x00 = int((shrink * p00.X) + 0.5)
+            y00 = int((shrink * p00.Y) + 0.5)
+            x11 = int((shrink * p11.X) + 0.5)
+            y11 = int((shrink * p11.Y) + 0.5)
+            x10 = int((shrink * p10.X) + 0.5)
+            y10 = int((shrink * p10.Y) + 0.5)
+            x01 = int((shrink * p01.X) + 0.5)
+            y01 = int((shrink * p01.Y) + 0.5)
+
+            if four_corners:
+                return Decoded(
+                    string_at(msg.contents.output),
+                    Rect_corners((x00,y00), (x01,y01), (x10,y10), (x11,y11))
+                )
+            else:
+                min_x = min(x00, x11, x10, x01)
+                max_x = max(x00, x11, x10, x01)
+                min_y = min(y00, y11, y10, y01)
+                max_y = max(y00, y11, y10, y01)
+
+                return Decoded(
+                    string_at(msg.contents.output),
+                    Rect(min_x, min_y, max_x - min_x, min_y - max_y)
+                    )
+
         else:
             return None
 
@@ -229,7 +248,7 @@ def _pixel_data(image):
 
 def decode(image, timeout=None, gap_size=None, shrink=1, shape=None,
            deviation=None, threshold=None, min_edge=None, max_edge=None,
-           corrections=None, max_count=None):
+           corrections=None, max_count=None, four_corners=False):
     """Decodes datamatrix barcodes in `image`.
 
     Args:
@@ -245,6 +264,7 @@ def decode(image, timeout=None, gap_size=None, shrink=1, shape=None,
         corrections (int):
         max_count (int): stop after reading this many barcodes. `None` to read
             as many as possible.
+        four_corners: If to return the four corners of the matrix or just one + width/height
 
     Returns:
         :obj:`list` of :obj:`Decoded`: The values decoded from barcodes.
@@ -289,7 +309,7 @@ def decode(image, timeout=None, gap_size=None, shrink=1, shape=None,
                     else:
                         # Decoded
                         res = _decode_region(
-                            decoder, region, corrections, shrink
+                            decoder, region, corrections, shrink, four_corners
                         )
                         if res:
                             results.append(res)

--- a/pylibdmtx/pylibdmtx.py
+++ b/pylibdmtx/pylibdmtx.py
@@ -37,7 +37,7 @@ ENCODING_SIZE_NAMES = [
 
 # A rectangle
 Rect = namedtuple('Rect', 'left top width height')
-Rect_corners = namedtuple('Rect', 'P0 P1 P3 P4')
+Rect_vertices = namedtuple('Rect', 'P0 P1 P3 P4')
 
 # Results of reading a barcode
 Decoded = namedtuple('Decoded', 'data rect')
@@ -147,7 +147,7 @@ def _decoded_matrix_region(decoder, region, corrections):
             dmtxMessageDestroy(byref(message))
 
 
-def _decode_region(decoder, region, corrections, shrink, four_corners):
+def _decode_region(decoder, region, corrections, shrink, return_vertices=False):
     """Decodes and returns the value in a region.
 
     Args:
@@ -176,10 +176,10 @@ def _decode_region(decoder, region, corrections, shrink, four_corners):
             x01 = int((shrink * p01.X) + 0.5)
             y01 = int((shrink * p01.Y) + 0.5)
 
-            if four_corners:
+            if return_vertices:
                 return Decoded(
                     string_at(msg.contents.output),
-                    Rect_corners((x00,y00), (x01,y01), (x10,y10), (x11,y11))
+                    Rect_vertices((x00,y00), (x01,y01), (x10,y10), (x11,y11))
                 )
             else:
                 min_x = min(x00, x11, x10, x01)
@@ -248,7 +248,7 @@ def _pixel_data(image):
 
 def decode(image, timeout=None, gap_size=None, shrink=1, shape=None,
            deviation=None, threshold=None, min_edge=None, max_edge=None,
-           corrections=None, max_count=None, four_corners=False):
+           corrections=None, max_count=None, return_vertices=False):
     """Decodes datamatrix barcodes in `image`.
 
     Args:
@@ -264,7 +264,7 @@ def decode(image, timeout=None, gap_size=None, shrink=1, shape=None,
         corrections (int):
         max_count (int): stop after reading this many barcodes. `None` to read
             as many as possible.
-        four_corners: If to return the four corners of the matrix or just one + width/height
+        return_vertices: If to return the coordinates of the four vertices of the datamatrix or just one + width/height
 
     Returns:
         :obj:`list` of :obj:`Decoded`: The values decoded from barcodes.
@@ -309,7 +309,7 @@ def decode(image, timeout=None, gap_size=None, shrink=1, shape=None,
                     else:
                         # Decoded
                         res = _decode_region(
-                            decoder, region, corrections, shrink, four_corners
+                            decoder, region, corrections, shrink, return_vertices
                         )
                         if res:
                             results.append(res)

--- a/pylibdmtx/pylibdmtx.py
+++ b/pylibdmtx/pylibdmtx.py
@@ -37,7 +37,7 @@ ENCODING_SIZE_NAMES = [
 
 # A rectangle
 Rect = namedtuple('Rect', 'left top width height')
-Rect_vertices = namedtuple('Rect', 'P0 P1 P3 P4')
+Rect_vertices = namedtuple('Rect', 'P0 P1 P2 P3')
 
 # Results of reading a barcode
 Decoded = namedtuple('Decoded', 'data rect')

--- a/pylibdmtx/pylibdmtx.py
+++ b/pylibdmtx/pylibdmtx.py
@@ -37,7 +37,7 @@ ENCODING_SIZE_NAMES = [
 
 # A rectangle
 Rect = namedtuple('Rect', 'left top width height')
-Rect_vertices = namedtuple('Rect', 'P0 P1 P2 P3')
+Rect_vertices = namedtuple('Rect_vertices', 'P0 P1 P2 P3')
 
 # Results of reading a barcode
 Decoded = namedtuple('Decoded', 'data rect')
@@ -189,7 +189,7 @@ def _decode_region(decoder, region, corrections, shrink, return_vertices=False):
 
                 return Decoded(
                     string_at(msg.contents.output),
-                    Rect(min_x, min_y, max_x - min_x, min_y - max_y)
+                    Rect(min_x, min_y, max_x - min_x, max_y - min_y)
                     )
 
         else:

--- a/pylibdmtx/wrapper.py
+++ b/pylibdmtx/wrapper.py
@@ -5,7 +5,7 @@ from ctypes import (
     c_ulonglong, c_char_p, Structure, CFUNCTYPE, POINTER
 )
 from enum import IntEnum, unique
-from distutils.version import LooseVersion
+from packaging import version
 
 from . import dmtx_library
 
@@ -196,7 +196,7 @@ DmtxMatrix3 = c_double * 3 * 3
 
 
 # Structs
-if LooseVersion(dmtxVersion()) < LooseVersion('0.7.5'):
+if version.parse(dmtxVersion()) < version.parse('0.7.5'):
     class DmtxMessage(Structure):
         _fields_ = [
             ('arraySize', c_size_t),
@@ -310,7 +310,7 @@ class DmtxScanGrid(Structure):
     ]
 
 
-if LooseVersion(dmtxVersion()) < LooseVersion('0.7.5'):
+if version.parse(dmtxVersion()) < version.parse('0.7.5'):
     class DmtxDecode(Structure):
         _fields_ = [
             ('edgeMin', c_int),
@@ -398,7 +398,7 @@ class DmtxRegion(Structure):
     ]
 
 
-if LooseVersion(dmtxVersion()) < LooseVersion('0.7.5'):
+if version.parse(dmtxVersion()) < version.parse('0.7.5'):
     class DmtxEncode(Structure):
         _fields_ = [
             ('method', c_int),


### PR DESCRIPTION
Hi

Thanks for creating pylibdmtx. I am using it to extract datamatrix from photos. Since the matrix in the photo can be rotated, I found myself in the situation described in issue #51. I have just implemented the code from @gauti1311 (https://github.com/NaturalHistoryMuseum/pylibdmtx/issues/51#issuecomment-582447839) and @jepperaskdk (https://github.com/NaturalHistoryMuseum/pylibdmtx/issues/51#issuecomment-1052125416) (a big thanks to both of them).

 I have added a boolean parameter to choose between returning a rectangle defined as before (left, top, width, height) but encompassing the whole datamatrix:
![image](https://user-images.githubusercontent.com/17795491/196168809-7b29d749-efa4-41ea-8a86-3c2ac5cc33c5.png)
or the coordinates of the four vertices (P0, P1, P2, P3): 
![image](https://user-images.githubusercontent.com/17795491/196169462-1672b873-2950-46c1-9d01-8b4f72ef0db2.png)
