### PR TITLE
Add FNC1 (and GS1) support

### DIFF
--- a/pylibdmtx/pylibdmtx.py
+++ b/pylibdmtx/pylibdmtx.py
@@ -313,7 +313,7 @@ def _encoder():
         dmtxEncodeDestroy(byref(encoder))
 
 
-def encode(data, scheme=None, size=None):
+def encode(data, scheme=None, size=None, fnc1=DmtxUndefined):
     """
     Encodes `data` in a DataMatrix image.
 
@@ -325,6 +325,8 @@ def encode(data, scheme=None, size=None):
             If `None`, defaults to 'Ascii'.
         size: image dimensions - one of `ENCODING_SIZE_NAMES`, or `None`.
             If `None`, defaults to 'ShapeAuto'.
+        fnc1: ASCII value of char to use as FNC1 or `None`. For example `43` (char '+') for data: '+12345+67890'
+            If `None`, defaults to `DmtxUndefined`. Will do nothing if libdmtx < 0.7.5.
 
     Returns:
         Encoded: with properties `(width, height, bpp, pixels)`.
@@ -334,6 +336,8 @@ def encode(data, scheme=None, size=None):
 
     """
 
+    fnc1 = fnc1 if fnc1 else DmtxUndefined
+    
     size = size if size else 'ShapeAuto'
     size_name = '{0}{1}'.format(ENCODING_SIZE_PREFIX, size)
     if not hasattr(DmtxSymbolSize, size_name):
@@ -357,6 +361,7 @@ def encode(data, scheme=None, size=None):
     scheme = getattr(DmtxScheme, scheme_name)
 
     with _encoder() as encoder:
+        dmtxEncodeSetProp(encoder, DmtxProperty.DmtxPropFnc1, fnc1)
         dmtxEncodeSetProp(encoder, DmtxProperty.DmtxPropScheme, scheme)
         dmtxEncodeSetProp(encoder, DmtxProperty.DmtxPropSizeRequest, size)
 


### PR DESCRIPTION
Support FNC1 char function in libdmtx: https://github.com/dmtx/libdmtx/pull/10

Simply pushing `\x1d` currently results in ASCII RS codeword (030) instead of actual FNC1 codeword (232), this commit fixes that.
As opposed to https://github.com/NaturalHistoryMuseum/pylibdmtx/pull/96 FNC1 is not prepended by default since it can be used on non-GS1 barcodes, and substitution char is customizable like in the original libdmtx commit.

(`fnc1=29` can be used to substitute `\x1d`)